### PR TITLE
Updates q42022

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,15 +19,16 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 11
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 Requirements:
 
- * Java >= 8
+ * Java >= 11 (openjdk 11.0.16 2022-07-19)
  * Maven
 
 To start a development Jenkins instance with this plugin loaded, run:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11'],
+])

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You must already have access to either Venafi TLS Protect (part of the Venafi Tr
 
         ~~~json
         {
-            "id": "fullstaq-vcert-jenkins",
-            "name": "Fullstaq VCert Jenkins",
-            "vendor": "Fullstaq B.V.",
+            "id": "qensus-vcert-jenkins",
+            "name": "Qensus VCert Jenkins",
+            "vendor": "Qensus B.V.",
             "description": "Venafi Machine Identity Management plugin for Jenkins",
             "scope": "certificate:manage"
         }
@@ -29,7 +29,7 @@ You must already have access to either Venafi TLS Protect (part of the Venafi Tr
 
         Then click Save.
 
-     6. Select the "Fullstaq VCert Jenkins" integration and click "Edit Access". Grant access to the TPP user account that you want to use from Jenkins.
+     6. Select the "Qensus VCert Jenkins" integration and click "Edit Access". Grant access to the TPP user account that you want to use from Jenkins.
 
 Once everything is set up, you are ready to proceed with main usage: see [Build steps & pipeline functions](#build-steps-pipeline-functions).
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-vcert</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>2.1.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -138,7 +138,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>venafi-vcert-2.1.0</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,15 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-vcert</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
         <java.level>11</java.level>
+        <workflow.version>2.0</workflow.version>
+        <revision>2.1.0</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
     <name>Venafi Machine Identity Management</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>venafi-vcert</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.361.2</jenkins.version>
@@ -138,7 +138,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>venafi-vcert-2.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.0</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,9 +12,8 @@
     <version>2.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.222.4</jenkins.version>
-        <java.level>8</java.level>
-        <workflow.version>2.0</workflow.version>
+        <jenkins.version>2.361.2</jenkins.version>
+        <java.level>11</java.level>
     </properties>
 
     <name>Venafi Machine Identity Management</name>
@@ -32,16 +31,16 @@
         <developer>
             <id>avwsolutions</id>
             <name>Arnold van Wijnbergen</name>
-            <email>a.vanwijnbergen@fullstaq.com</email>
-            <organization>Fullstaq</organization>
-            <organizationUrl>https://fullstaq.com</organizationUrl>
+            <email>arnold@qensus.com</email>
+            <organization>Qensus Labs</organization>
+            <organizationUrl>https://qensus.com</organizationUrl>
         </developer>
         <developer>
-            <id>FooBarWidget</id>
-            <name>Hongli Lai</name>
-            <email>h.lai@fullstaq.com</email>
-            <organization>Fullstaq</organization>
-            <organizationUrl>https://fullstaq.com</organizationUrl>
+            <id>sanhi</id>
+            <name>Sander Hindimith</name>
+            <email>sander@hindimith.nl</email>
+            <organization>Qensus Labs</organization>
+            <organizationUrl>https://qensus.com</organizationUrl>
         </developer>
     </developers>
 
@@ -51,7 +50,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.0.0-M7</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -62,20 +61,20 @@
             <dependency>
                 <!-- Pick up common dependencies for 2.164.x: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>3</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1607.va_c1576527071</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
-                <version>4.9.2</version>
+                <version>4.11.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
-                <version>1.22</version>
+                <version>1.23</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -84,32 +83,28 @@
         <dependency>
             <groupId>io.github.venafi</groupId>
             <artifactId>vcert-java</artifactId>
-            <version>0.6.2</version>
+            <version>0.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
+            <version>3.12.0</version>
         </dependency>
 
         <!-- Dependencies for allowing inspection with IntelliSense.


### PR DESCRIPTION
### Release v2.1.0

**This is a new minor release with backward compatible changes!** 

**Important to ensure you are running at least version 2.361.2 or greater!**

Possible breaking changes:

- Updates to Jenkins core 2.361.2 and introducing JDK11.

Non-breaking changes:

- Upgrades vcert-java to 0.9.3 to solve log4Shell vulnerability.
- Upgrade base plugins towards bom-2.361.x, version 1607.va_c1576527071
- Bumps various dependencies versions in order to fix their security issues.
- Minor documentation updates.
- Minor Actions updates to make the workflow JDK11 compatible.